### PR TITLE
Check generated build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,19 @@
-name: build-workflow
-on: [push]
+name: Check generated build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
 jobs:
-  build-job:
+  generated-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-      - run: bun install
-      - run: bun run build
-      - run: |
-          git config --global user.name 'Paul Holden'
-          git config --global user.email 'hulkholden@users.noreply.github.com'
-          git add -A
-          git diff-index --quiet HEAD || git commit -m 'Automated build'
-          git push
+      - uses: oven-sh/setup-bun@v2
+      - run: bun ci
+      - run: bun run check:build

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Compile sources (pass --watch to automatically recompile on any change):
 bun run build --watch
 ```
 
+The generated `build/n64.min.js` file is committed to the repository. Before
+submitting changes, verify that it is up to date:
+
+```
+bun run check:build
+```
+
 Run a local webserver in the root directory:
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "n64js",
   "version": "1.0.0",
+  "packageManager": "bun@1.3.14",
   "description": "An JavaScript N64 emulator.",
   "main": "n64.min.js",
   "type": "module",
   "scripts": {
     "build": "bun build ./src/n64.js --outfile=build/n64.min.js --minify",
-    "build-debug": "bun build ./src/n64.js --outfile=build/n64.min.js"
+    "build-debug": "bun build ./src/n64.js --outfile=build/n64.min.js",
+    "check:build": "bun run build && git diff --exit-code -- build/n64.min.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- replace the workflow that commits and pushes generated output with a read-only CI check
- pin Bun 1.3.14 and use the frozen lockfile via `bun ci`
- add and document `bun run check:build` for contributors

## Verification
- `bun ci`
- `bun run check:build`